### PR TITLE
changed method for getting number of clients per worker

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -154,7 +154,7 @@ function start() {
         isRandomDelay=true;
     }
     http.globalAgent.maxSockets=maxSockets;
-    var clientsPerWorker=parseInt((clients/workers).toFixed());
+    var clientsPerWorker=Math.ceil(clients/workers);
     var startTime=new Date().getTime()/1000;//sec
     var numberOfTotalRequestsPerWorker=numberOfTotalRequestsPerClient>0?numberOfTotalRequestsPerClient*clientsPerWorker:-1;
 


### PR DESCRIPTION
Issue:

> This bug is because of `parseInt((clients/workers).toFixed())` in line `157` of `main.js`. Because this line results in 0. Therefore the number of clients will be 0. And `no request is sent`.

Solution:

> Using `Math.ceil()` for getting number of clients per worker.

**Files updated:**

- main.js