### PR TITLE
fix for missing body in throttling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -395,6 +395,7 @@ function request(options,cb){
         var proxyPort=process.pid%60000;
         _options.host=localProxyHost;
         _options.port=proxyPort;
+        _options.method=method;
         if(options.headers !=null){
             _options.headers=options.headers;
         }else{


### PR DESCRIPTION
**PR for #29**

This pr includes fix for body data missing when throttling 

Cause

> method was not specified when proxying the request

File updated

- main.js