### PR TITLE
handling temp garbage files

### DIFF
--- a/desktop-app/main-process/handleGarbage.js
+++ b/desktop-app/main-process/handleGarbage.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const { APP_NAME } = require('../Constants/constants');
+
+const folder = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + `/Library/Application Support/${APP_NAME}/Temp/` : process.env.HOME + `/.config/${APP_NAME}/Temp/`)
+
+fs.readdir(folder, (err, files) => {
+    if (err) throw err;
+    for (const file of files) {
+        console.log(file + ' : temporary file cleared');
+        fs.unlinkSync(folder + file);
+    }
+});

--- a/desktop-app/public/main.js
+++ b/desktop-app/public/main.js
@@ -1,4 +1,5 @@
 require('../main-process/start')
+require('../main-process/handleGarbage')
 require('../main-process/Projects/projects.main')
 require('../main-process/Scenarios/scenarios.main')
 require('../main-process/Requests/requests.main')


### PR DESCRIPTION
### Issue: Memory leak
When the process ends due to any reason whether the user ends the request or shut down the app, the files that are  generated for temporary purposes remain in the **/Temp** folder even if the process is no longer alive

### Solution: Deleting all the temp files when the app start initially

### Changes: Below files are added and modified

- `/Desktop-App/public/main.js` - Modified
- `/Desktop-App/main-process/handleGarbage.js` - Added